### PR TITLE
FEAT: add-read, seek, tell, close, edit-write, init_thread

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,5 +149,7 @@ fabric.properties
 *.dsk
 *.txt
 *.log
+tests/
+userprog/build/tests/
 
 results

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -104,7 +104,7 @@ struct thread
 	uint64_t *pml4; /* Page map level 4 */
 
 	/* system call */
-	struct file_entry *fdt[32];
+	struct file_entry **fdt;
 	uint64_t fdt_index;
 #endif
 #ifdef VM

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -587,7 +587,9 @@ init_thread(struct thread *t, const char *name, int priority)
 	t->nice = 0;
 	t->recent_cpu = 0;
 #ifdef USERPROG
-	t->fdt_index = 3;
+	t->fdt_index = 2;
+	list_init(&t->file_table);
+	t->fdt = palloc_get_multiple(PAL_ZERO, 3);		// for multi-oom test
 #endif
 	if (thread_mlfqs)
 		list_push_back(&thread_list, &t->thread_elem);
@@ -737,6 +739,9 @@ do_schedule(int status)
 	{
 		struct thread *victim =
 			list_entry(list_pop_front(&destruction_req), struct thread, elem);
+#ifdef USERPROG
+		palloc_free_multiple(t->fdt, 3);
+#endif
 		palloc_free_page(victim);
 	}
 	thread_current()->status = status;

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -281,7 +281,7 @@ void process_exit(void)
 	 * TODO: Implement process termination message (see
 	 * TODO: project2/process_termination.html).
 	 * TODO: We recommend you to implement process resource cleanup here. */
-
+	
 	process_cleanup();
 }
 
@@ -504,7 +504,7 @@ load(const char *file_name, struct intr_frame *if_)
 
 done:
 	/* We arrive here whether the load is successful or not. */
-	// msg("fail");
+
 	file_close(file);
 	return success;
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -21,6 +21,9 @@
 #define MSR_STAR 0xc0000081			/* Segment selector msr */
 #define MSR_LSTAR 0xc0000082		/* Long mode SYSCALL target */
 #define MSR_SYSCALL_MASK 0xc0000084 /* Mask for the eflags */
+#define MAX_STDOUT 1<<9
+
+#define GET_FILE_ETY(fdt, fd) (*((fdt) + fd))
 
 struct file_entry
 {
@@ -57,20 +60,11 @@ void syscall_init(void)
 			  FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
 }
 
-void check_address(void *uaddr)
-{
-	struct thread *cur = thread_current();
-	if (uaddr == NULL || is_kernel_vaddr(uaddr) || pml4_get_page(cur->pml4, uaddr) == NULL)
-	{
-		exit(-1);
-	}
-}
-
 /* The main system call interface */
 void syscall_handler(struct intr_frame *f UNUSED)
 {
-	int temp = f->R.rax;
-	switch (temp)
+	int syscall = f->R.rax;
+	switch (syscall)
 	{
 	case SYS_HALT:
 		halt();
@@ -84,9 +78,12 @@ void syscall_handler(struct intr_frame *f UNUSED)
 		break;
 
 	case SYS_CREATE:
-		create(f->R.rdi, f->R.rsi);
+		bool succ = create(f->R.rdi, f->R.rsi);
+		f->R.rax = succ;
 		break;
 	case SYS_REMOVE:
+		bool succ = remove(f->R.rdi);
+		f->R.rax = succ;
 		break;
 	case SYS_OPEN:
 		int fd = open(f->R.rdi);
@@ -97,21 +94,37 @@ void syscall_handler(struct intr_frame *f UNUSED)
 		f->R.rax = size;
 		break;
 	case SYS_READ:
+		int byte_read = read(f->R.rdi, f->R.rsi, f->R.rdx);
+		f->R.rax = byte_read;
 		break;
 	case SYS_WRITE:
-		write(f->R.rdi, f->R.rsi, f->R.rdx);
+		int byte_written = write(f->R.rdi, f->R.rsi, f->R.rdx);
+		f->R.rax = byte_written;
 		break;
 	case SYS_SEEK:
+		seek(f->R.rdi, f->R.rsi);
 		break;
 	case SYS_TELL:
+		int next_pos = tell(f->R.rdi);
+		f->R.rax = next_pos;
 		break;
 	case SYS_CLOSE:
+		close(f->R.rdi);
 		break;
 	default:
+		printf("We don't implemented yet.");
 		break;
 	}
-	// check_address(&f);
-	//  TODO: Your implementation goes here.
+}
+/* 
+ * 요청된 user 가상주소값이 1.NULL이 아닌지 2. kernel영역을 참조하는지 
+ * 3. 물리주소내에 mapping하는지 확인하여 위반하는경우 종료
+ */
+void check_address(void *uaddr)
+{
+	struct thread *cur = thread_current();
+	if (uaddr == NULL || is_kernel_vaddr(uaddr) || pml4_get_page(cur->pml4, uaddr) == NULL)
+		exit(-1);
 }
 
 void halt()
@@ -121,7 +134,6 @@ void halt()
 
 void exit(int status)
 {
-
 	printf("%s: exit(%d)\n", thread_current()->name, status);
 	thread_exit();
 }
@@ -132,76 +144,153 @@ pid_t fork(const char *thread_name)
 }
 int exec(const char *file);
 int wait(pid_t);
+
 bool create(const char *file, unsigned initial_size)
 {
 	check_address(file);
-	bool success;
-	success = filesys_create(file, initial_size);
-	return success;
+	return filesys_create(file, initial_size);
 }
+
 bool remove(const char *file)
 {
 	check_address(file);
-	bool success;
-	success = filesys_remove(file);
-	return success;
+	return filesys_remove(file);
 }
 
+/* 
+ * 잘못된 파일 이름을 가지거나 disk에 파일이 없는경우 -1 반환.
+ * thread 내에 file_entry ptr을 저장한 뒤, 표준입출력을 제외한 3부터 증가하는 fd 값을 반환.
+ */
 int open(const char *file)
 {
 	check_address(file);
-	struct file *entry = filesys_open(file);
-	struct file_entry *file_table;
-	file_table->file = entry;
-	file_table->refcnt = 1;
-	if (entry == NULL)
+	struct file *file_entity = filesys_open(file);
+	struct file_entry *file_object = calloc(1, sizeof(file_entry));
+	file_object->file = file_entity;
+	file_object->refcnt = 1;			// for fork  
+	if (file_entity == NULL)			// wrong file name or not in disk (initialized from arg -p)
 		return -1;
+
+	// initialize
 	struct thread *cur = thread_current();
-	int fd = cur->fdt_index++;
-	cur->fdt[fd] = file_table;
+	int fd = ++cur->fdt_index;
+	GET_FILE_ETY(cur->fdt, fd) = file_object;
 	return fd;
 }
 
 int filesize(int fd)
 {
 	struct thread *cur = thread_current();
-	int length;
-	length = file_length(cur->fdt[fd]->file);
-	return length;
+	ASSERT(3 <= fd);
+
+	return file_length(GET_FILE_ETY(cur->fdt, fd)->file);
 }
-int read(int fd, void *buffer, unsigned length);
+
+/* 
+ * fd값에 따라 읽은 만큼 byte(<=length)값 반환, 못 읽는 경우 -1, 읽을 지점이 파일의 끝인경우 0 반환
+ * 참고 : disk read(file_read)와 intq_getc(input_getc)에 lock이 걸려있음 
+ */
+int read(int fd, void *buffer, unsigned length)
+{	
+	check_address(buffer);
+	struct thread *cur = thread_current();
+	int bytes_read = length;	
+	switch (fd)
+	{	
+		case 0:
+			uint8_t byte;
+			while (length--){
+				byte = input_getc();			// console 입력을 받아
+				*(char *)buffer++ = byte;		// 1byte씩 저장
+			}
+			break;
+		case 1:
+		case 2:		
+			return -1;	// wrong fd 
+
+		default:
+			if (fd > cur->fdt_index)	// wrong fd 
+				return -1;
+
+			struct file *cur_file = GET_FILE_ETY(cur->fdt, fd)->file;	
+			if (cur_file->pos == inode_length(cur_file->inode))		// end of file
+				return 0;
+
+			if ((bytes_read = file_read(cur_file, buffer, length)) == 0)	// could not read
+				return -1;		
+			break;
+	}
+	return bytes_read;
+}
+
+/* 
+ * fd값에 따라 적은 만큼 byte(<=length)값 반환, 못 적는 경우 -1 반환
+ * 참고 : disk write에 lock이 걸려있음
+ */
 int write(int fd, const void *buffer, unsigned length)
 {
-	/* fd == 0 => stdin
-	   fd == 1 => stdout
-	   fd == 2 => stderr */
+	/* fd == 0 => stdin, fd == 1 => stdout, fd == 2 => stderr */
 	check_address(buffer);
+	struct thread *cur = thread_current();
+	if (0 == fd)	// no bytes could be written at all
+		return 0;
+
+	int bytes_write = length;	
 	switch (fd)
 	{
-	case 0:
-		ASSERT(fd != 0)
-		break;
+		case 1: // stdout: lock을 걸고 buffer 전체를 입력
+			uint8_t iter_cnt = length / MAX_STDOUT + 1;
+			uint16_t less_size;
+			while (iter_cnt--){			// 입력 buffer가 512보다 큰경우 slicing 해서 출력 (for test)
+				less_size = (length > MAX_STDOUT) ? MAX_STDOUT : length;
+				putbuf(buffer, less_size);
+				buffer += less_size;
+				length -= MAX_STDOUT;
+			}
+			break;
 
-	case 1: // stdout
-	case 2: // stderr
-		putbuf(buffer, length);
-		break;
+		case 2: // stderr: (stdout과 다르게 어떻게 해야할지 모르겠음)한글자씩 작성할때마다 lock이 걸림
+			while (length-- > 0)
+				putchar(buffer++);	
+			break;
 
-	default:
-		break;
+		default:	// file growth is not implemented by the basic file system
+			struct file *cur_file = GET_FILE_ETY(cur->fdt, fd)->file;	
+			bytes_write = file_write(cur_file, buffer, length);
+			break;
 	}
-
-	// unsigned write_byte = 0;
-	// write_byte = memcpy(thread_current()->tf.rsp, buffer, length);
-	// if (write_byte <= 0)
-	// {
-	// 	printf(" ERROR!!!! WRITE FAIL");
-	// }
-	// else
-	// {
-	// 	printf(" 작성에 성공한 바이트 숫자 = %d\n", write_byte);
-	// }
+	return bytes_write;
 }
-void seek(int fd, unsigned position);
-unsigned tell(int fd);
-void close(int fd);
+
+/* 파일 크기가 넘어가는 position인 경우 write할 때 자동으로 0으로 채워지는지 확인해야됨*/
+void seek(int fd, unsigned position)
+{	
+	struct thread *cur = thread_current();
+	ASSERT(3 <= fd);
+
+	struct file *cur_file = GET_FILE_ETY(cur->fdt, fd)->file;	
+	file_seek(cur_file, position);
+}
+
+unsigned tell(int fd)
+{
+	struct thread *cur = thread_current();
+	ASSERT(3 <= fd);
+
+	struct file *cur_file = GET_FILE_ETY(cur->fdt, fd)->file;	
+	return file_tell(cur_file);
+}
+
+void close(int fd)
+{
+	struct thread *cur = thread_current();
+	ASSERT(3 <= fd);
+
+	struct file_entry *cur_file_entry = GET_FILE_ETY(cur->fdt, fd);
+	if (cur_file_entry->refcnt > 0)				// if fork
+		cur_file_entry->refcnt--;
+	else{
+		file_close(cur_file_entry->file);
+		free(cur_file_entry);
+	}
+}


### PR DESCRIPTION
코드 수정을 많이 했는데 불필요한 부분 지적 부탁드립니다.
아래는 제가 작성한 부분과 앞으로 해야될 부분을 적었습니다.

변경사항
1. tests/userprog/no-vm/multi-oom.c test를 위해 palloc_get_multiple 추가
2. 1에 의해 포인터 배열을 투포인터로 바꿈, 
3. t->fdt_index 를 현재의 thread의 fdt index를 가리키도록 2로 변경
4. write 구체화

추가사항
1. read, seek, tell, close (수정 필요)
2. open 함수에서 calloc 추가
3. 중요 함수에 대해 주석 추가

고려해야 될부분
1. exit printf 메시지 작성시 kernel thread인 경우 출력 x(Process Termination Message)
2. read wirte 이외에 다른 filesys 에 접근하는 syscall 역시 lock을 걸어야 할것인가? process_exec()에서 open할 때도 포함
3. 과제 설명서엔 file의 ref_cnt를 고려해야한다는 부분이 없는데 제외해야 될것인가?
4. close를 process가 exiting 하거나 terminate하는 경우 자동적으로 호출해야 되는 부분 process.c에서 구현 필요
5. malloc에서 사용한 비트마스킹을 통해(첫번째 field가 ptr이므로 가능) macro와  함수들을 만들고 open과 close를 수정해야함 (현재 fdt_inex를 사용하는것은 메모리 낭비가 심함)
5.1 fdt내 유효한 fd인지 check 하는 macro
5.2 (open 할때 사용하기 위해) fdt를 순회하면서(sizeof file_entry만큼 fdt table 메모리 주소를 이동하면서) 유효하지 않은 fd를 return 하는 함수
