### PR TITLE
compelte file system call (72/95)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,14 +1,33 @@
 {
-    "configurations": [
-      {
-        "type": "gdb",
-        "request": "attach",
-        "name": "Attach to gdbserver : threads",
-        "executable": "${workspaceRoot}/threads/build/kernel.o",
-        "target": "localhost:1234",
-        "remote": true,
-        "cwd": "${workspaceRoot}",
-        "valuesFormatting": "parseText"
-      }
-    ]
-  }
+  "configurations": [
+    {
+      "type": "gdb",
+      "request": "attach",
+      "name": "Attach to gdbserver : userprog",
+      "executable": "${workspaceRoot}/userprog/build/kernel.o",
+      "target": "localhost:1234",
+      "remote": true,
+      "cwd": "${workspaceRoot}",
+      "valuesFormatting": "parseText"
+    },
+    {
+      "name": "C/C++ Runner: Debug Session",
+      "type": "cppdbg",
+      "request": "launch",
+      "args": [],
+      "stopAtEntry": false,
+      "externalConsole": false,
+      "cwd": "/home/ubuntu/cproject/pintos11/threads",
+      "program": "/home/ubuntu/cproject/pintos11/threads/build/Debug/outDebug",
+      "MIMode": "gdb",
+      "miDebuggerPath": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
-    "files.associations": {
-        "stdbool.h": "c"
-    }
+  "files.associations": {
+    "stdbool.h": "c",
+    "string.h": "c",
+    "inode.h": "c",
+    "file.h": "c"
+  },
+  "C_Cpp_Runner.msvcBatchPath": ""
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,10 @@
     "stdbool.h": "c",
     "string.h": "c",
     "inode.h": "c",
-    "file.h": "c"
+    "file.h": "c",
+    "debug.h": "c",
+    "filesys.h": "c",
+    "*.inc": "c"
   },
   "C_Cpp_Runner.msvcBatchPath": ""
 }

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -105,7 +105,6 @@ struct thread
 
 	/* system call */
 	struct file_entry **fdt;
-	uint64_t fdt_index;
 #endif
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */

--- a/tests/userprog/bad-read.c
+++ b/tests/userprog/bad-read.c
@@ -6,7 +6,7 @@
 
 void
 test_main (void) 
-{
+{ 
   msg ("Congratulations - you have successfully dereferenced NULL: %d", 
         *(int *)NULL);
   fail ("should have exited with -1");

--- a/userprog/build/Makefile
+++ b/userprog/build/Makefile
@@ -1,0 +1,64 @@
+# -*- makefile -*-
+
+SRCDIR = ../..
+
+all: os.dsk
+
+include ../../Make.config
+include ../Make.vars
+include ../../tests/Make.tests
+
+# Compiler and assembler options.
+os.dsk: CPPFLAGS += -I$(SRCDIR)/lib/kernel
+
+# Core kernel.
+include ../../threads/targets.mk
+# User process code.
+include ../../userprog/targets.mk
+# Virtual memory code.
+include ../../vm/targets.mk
+# Filesystem code.
+include ../../filesys/targets.mk
+# Library code shared between kernel and user programs.
+include ../../lib/targets.mk
+# Kernel-specific library code.
+include ../../lib/kernel/targets.mk
+# Device driver code.
+include ../../devices/targets.mk
+
+SOURCES = $(foreach dir,$(KERNEL_SUBDIRS),$($(dir)_SRC))
+OBJECTS = $(patsubst %.c,%.o,$(patsubst %.S,%.o,$(SOURCES)))
+DEPENDS = $(patsubst %.o,%.d,$(OBJECTS))
+
+threads/kernel.lds.s: CPPFLAGS += -P
+threads/kernel.lds.s: threads/kernel.lds.S
+
+kernel.o: threads/kernel.lds.s $(OBJECTS)
+	$(LD) $(LDFLAGS) -T $< -o $@ $(OBJECTS)
+
+kernel.bin: kernel.o
+	$(OBJCOPY) -O binary -R .note -R .comment -S $< $@.tmp
+	dd if=$@.tmp of=$@ bs=4096 conv=sync
+	rm $@.tmp
+
+threads/loader.o: threads/loader.S kernel.bin
+	$(CC) -c $< -o $@ $(ASFLAGS) $(CPPFLAGS) $(DEFINES) -DKERNEL_LOAD_PAGES=`perl -e 'print +(-s "kernel.bin") / 4096;'`
+
+loader.bin: threads/loader.o
+	$(LD) $(LDFLAGS) -N -e start -Ttext 0x7c00 --oformat binary -o $@ $<
+
+os.dsk: loader.bin kernel.bin
+	cat $^ > $@
+
+clean::
+	rm -f $(OBJECTS) $(DEPENDS)
+	rm -f threads/loader.o threads/kernel.lds.s threads/loader.d
+	rm -f kernel.o kernel.lds.s
+	rm -f kernel.bin loader.bin os.dsk
+	rm -f bochsout.txt bochsrc.txt
+	rm -f results grade
+
+Makefile: $(SRCDIR)/Makefile.build
+	cp $< $@
+
+-include $(DEPENDS)

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -85,6 +85,9 @@ kill (struct intr_frame *f) {
 			   expected.  Kill the user process.  */
 			printf ("%s: dying due to interrupt %#04llx (%s).\n",
 					thread_name (), f->vec_no, intr_name (f->vec_no));
+#ifdef USERPROG
+			check_address(f->R.rax);
+#endif
 			intr_dump_frame (f);
 			thread_exit ();
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -52,6 +52,8 @@ tid_t process_create_initd(const char *file_name)
 	strlcpy(fn_copy, file_name, PGSIZE);
 
 	/* Create a new thread to execute FILE_NAME. */
+	char *next_ptr;
+	strtok_r(file_name, " ", &next_ptr);
 	tid = thread_create(file_name, PRI_DEFAULT, initd, fn_copy);
 	if (tid == TID_ERROR)
 		palloc_free_page(fn_copy);
@@ -208,10 +210,10 @@ int process_exec(void *f_name)
 		total_size += len;
 	}
 
-	size_t remainder = total_size % 8;
+	size_t remainder = (total_size + 8 + 8 * temp_cnt) % 16;
 	if (remainder != 0)
 	{
-		size_t padding_size = 8 - remainder;
+		size_t padding_size = 16 - remainder;
 		_if.rsp -= padding_size;
 
 		// 패딩된 영역을 0으로 초기화합니다.
@@ -264,9 +266,13 @@ void push_register(struct intr_frame _if, char *temp, char filename)
  * does nothing. */
 int process_wait(tid_t child_tid UNUSED)
 {
+	// thread_sleep(150);
 	while (1)
 	{
 	}
+	// for (int i = 0; i < 100000000; i++)
+	// {
+	// }
 	return -1;
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
@@ -281,7 +287,7 @@ void process_exit(void)
 	 * TODO: Implement process termination message (see
 	 * TODO: project2/process_termination.html).
 	 * TODO: We recommend you to implement process resource cleanup here. */
-	
+
 	process_cleanup();
 }
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -282,12 +282,6 @@ int process_wait(tid_t child_tid UNUSED)
 /* Exit the process. This function is called by thread_exit (). */
 void process_exit(void)
 {
-	struct thread *curr = thread_current();
-	/* TODO: Your code goes here.
-	 * TODO: Implement process termination message (see
-	 * TODO: project2/process_termination.html).
-	 * TODO: We recommend you to implement process resource cleanup here. */
-
 	process_cleanup();
 }
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -267,12 +267,12 @@ void push_register(struct intr_frame _if, char *temp, char filename)
 int process_wait(tid_t child_tid UNUSED)
 {
 	// thread_sleep(150);
-	while (1)
-	{
-	}
-	// for (int i = 0; i < 100000000; i++)
+	// while (1)
 	// {
 	// }
+	for (int i = 0; i < 100000000; i++)
+	{
+	}
 	return -1;
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -25,6 +25,9 @@
 
 #define GET_FILE_ETY(fdt, fd) (*((fdt) + (fd)))
 
+/* system call */
+struct lock filesys_lock;
+
 struct file_entry
 {
 	struct file *file;
@@ -58,12 +61,15 @@ void syscall_init(void)
 	 * mode stack. Therefore, we masked the FLAG_FL. */
 	write_msr(MSR_SYSCALL_MASK,
 			  FLAG_IF | FLAG_TF | FLAG_DF | FLAG_IOPL | FLAG_AC | FLAG_NT);
+	lock_init(&filesys_lock);
 }
 
 /* The main system call interface */
 void syscall_handler(struct intr_frame *f UNUSED)
 {
 	int syscall = f->R.rax;
+	if ((5 <= syscall) && (syscall <= 13))
+		lock_acquire(&filesys_lock);
 	switch (syscall)
 	{
 	case SYS_HALT:
@@ -115,6 +121,8 @@ void syscall_handler(struct intr_frame *f UNUSED)
 		printf("We don't implemented yet.");
 		break;
 	}
+	if ((5 <= syscall) && (syscall <= 13))
+		lock_release(&filesys_lock);
 }
 /*
  * 요청된 user 가상주소값이 1.NULL이 아닌지 2. kernel영역을 참조하는지


### PR DESCRIPTION
pass tests/threads/priority-donate-chain
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
FAIL tests/userprog/fork-once
FAIL tests/userprog/fork-multiple
FAIL tests/userprog/fork-recursive
FAIL tests/userprog/fork-read
FAIL tests/userprog/fork-close
FAIL tests/userprog/fork-boundary
FAIL tests/userprog/exec-once
FAIL tests/userprog/exec-arg
FAIL tests/userprog/exec-boundary
FAIL tests/userprog/exec-missing
FAIL tests/userprog/exec-bad-ptr
FAIL tests/userprog/exec-read
FAIL tests/userprog/wait-simple
FAIL tests/userprog/wait-twice
FAIL tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
FAIL tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
FAIL tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
FAIL tests/userprog/no-vm/multi-oom
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
23 of 95 tests failed.

syscall fork, exec, wait 제외하고 구현 완료!